### PR TITLE
Refactor: Centralize build configurations and update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-
-
-
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
@@ -26,11 +23,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup JDK 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup gradle
@@ -52,10 +49,10 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v3
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup gradle
@@ -77,10 +74,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup gradle
@@ -125,7 +122,6 @@ jobs:
         run: |
           ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
 
-
       - name: Create new release from tag
         env:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -133,5 +129,3 @@ jobs:
         with:
           generate_release_notes: true
           token: ${{ env.github_token }}
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,9 @@ jobs:
     name: Build ${{ matrix.config.target }}
     needs: check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1
+        uses: gradle/gradle-build-action@v3
 
       - name: Check api
         run: ./gradlew apiCheck
@@ -56,7 +56,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1
+        uses: gradle/gradle-build-action@v3
 
       - name: Test ${{ matrix.config.target }} targets
         continue-on-error: ${{ matrix.config.continueOnError }}
@@ -81,7 +81,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1
+        uses: gradle/gradle-build-action@v3
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,9 @@
+buildscript {
+    dependencies {
+        classpath(libs.huawei.services)
+    }
+}
+
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
@@ -10,7 +16,7 @@ plugins {
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.kotlinx.binary.validator)
     alias(libs.plugins.mavenPublish) apply false
-    id("com.google.gms.google-services") version "4.4.0" apply false
+    alias(libs.plugins.google.services) apply false
 }
 
 apiValidation {
@@ -22,19 +28,9 @@ apiValidation {
 }
 
 allprojects {
-    group = "io.github.mirzemehdi"
-    version = project.properties["kmpNotifierVersion"] as String
-
-
     val excludedModules = listOf(":sample")
     if (project.path in excludedModules) return@allprojects
 
-    apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "maven-publish")
     apply(plugin = "signing")
 }
-
-
-
-
-

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,19 @@
+@file:Suppress("UnstableApiUsage")
+
+
+
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    google()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation(gradleApi())
+    implementation(gradleKotlinDsl())
+    implementation(libs.gradle.api)
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,5 +15,5 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation(gradleKotlinDsl())
-    implementation(libs.gradle.api)
+    implementation(libs.gradle.android)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,19 @@
+@file:Suppress("UnstableApiUsage")
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        google()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,0 +1,15 @@
+@file:Suppress("unused")
+
+
+object Config {
+    const val PACKAGE_ID = "com.mmk.kmpnotifier"
+    const val ARTIFACT_ID = "kmpnotifier"
+    const val ARTIFACT_GROUP_ID = "io.github.mirzemehdi"
+    const val ARTIFACT_VERSION = "1.5.2"
+    const val LIBRARY_NAME = "KMPNotifier"
+    const val LIBRARY_DESCRIPTION = "Kotlin Multiplatform Push Notification Library targeting ios and android"
+    const val DEVELOPER_NAME = "Mirzamehdi Karimov"
+    const val DEVELOPER_EMAIL = "mirzemehdi@gmail.com"
+    const val GITHUB_USERNAME = "mirzemehdi"
+    const val GITHUB_REPOSITORY_NAME = "KMPNotifier"
+}

--- a/buildSrc/src/main/kotlin/maven/mavenPublish.kt
+++ b/buildSrc/src/main/kotlin/maven/mavenPublish.kt
@@ -1,0 +1,42 @@
+@file:Suppress("unused")
+
+package maven
+
+import org.gradle.api.publish.maven.MavenPom
+import org.gradle.api.publish.maven.MavenPomLicenseSpec
+
+
+fun MavenPom.configure(
+    libraryName: String,
+    libraryDescription: String,
+    developerName: String,
+    developerEmail: String,
+    githubUsername: String,
+    githubRepositoryName: String,
+    licenseConfig: MavenPomLicenseSpec.() -> Unit = {
+        name.set("Apache-2.0")
+        url.set("https://opensource.org/licenses/Apache-2.0")
+    }
+) {
+    val repoUrl = "https://github.com/$githubUsername/$githubRepositoryName"
+    url.set(repoUrl)
+    name.set(libraryName)
+    description.set(libraryDescription)
+    licenses {
+        license { licenseConfig() }
+    }
+    developers {
+        developer {
+            name.set(developerName)
+            email.set(developerEmail)
+        }
+    }
+    scm {
+        url.set(repoUrl)
+        connection.set("$repoUrl.git")
+    }
+    issueManagement {
+        system.set("Github")
+        url.set("$repoUrl/issues")
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,6 @@ kotlin.mpp.enableCInteropCommonization=true
 #Development
 development=true
 
-kmpNotifierVersion=1.5.1
+kmpNotifierVersion=1.5.2
+kotlin.apple.xcodeCompatibility.nowarn=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,39 +1,41 @@
 [versions]
-compose = "1.7.8"
-compose-plugin = "1.7.3"
-agp = "8.7.3"
+compose = "1.8.3"
+compose-plugin = "1.8.2"
+agp = "8.11.0"
 android-minSdk = "21"
-android-compileSdk = "35"
-android-targetSdk = "35"
+android-compileSdk = "36"
+android-targetSdk = "36"
 androidx-activityCompose = "1.10.1"
-androidx-core-ktx = "1.15.0"
+androidx-core-ktx = "1.16.0"
 androidx-startup-runtime = "1.2.0"
-kotlin = "2.1.10"
-koin = "4.0.2"
-kotlinx-binary-validator = "0.16.3"
+kotlin = "2.1.21"
+koin = "4.1.0"
+kotlinx-binary-validator = "0.18.0"
 dokka = "2.0.0"
-firebase-messaging = "24.1.0"
-kotlinx-coroutine = "1.10.1"
+firebase-messaging = "24.1.2"
+kotlinx-coroutine = "1.10.2"
 kotlinx-browser = "0.3"
-mavenPublish = "0.31.0"
-
-
-
+mavenPublish = "0.33.0"
+google-services = "4.4.3"
+huawei-push = "6.13.0.300"
+huawei-services = "1.9.3.301"
 
 [libraries]
+gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutine = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutine" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activityCompose" }
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup-runtime" }
-koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
-firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging-ktx" ,version.ref="firebase-messaging"}
-
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+huawei-push = { module = "com.huawei.hms:push", version.ref = "huawei-push" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging-ktx", version.ref = "firebase-messaging" }
+huawei-services = { module = "com.huawei.agconnect:agcp", version.ref = "huawei-services" }
 
 [plugins]
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
@@ -45,3 +47,19 @@ kotlinNativeCocoaPods = { id = "org.jetbrains.kotlin.native.cocoapods", version.
 kotlinx-binary-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-validator" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
+huawei-services = { id = "com.huawei.agconnect" }
+kmpnotifier = { id = "com.mmk.kmpnotifier" }
+kmpnotifier-library = { id = "com.mmk.kmpnotifier.library" }
+
+[bundles]
+androidMain = [
+    "androidx-core-ktx",
+    "androidx-activity-ktx",
+    "androidx-startup-runtime"
+]
+
+commonMain = [
+    "koin-core",
+    "kotlinx-coroutine"
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,8 @@ huawei-push = "6.13.0.300"
 huawei-services = "1.9.3.301"
 
 [libraries]
-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
+gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+gradle-android = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutine = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutine" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,8 +55,9 @@ kmpnotifier-library = { id = "com.mmk.kmpnotifier.library" }
 [bundles]
 androidMain = [
     "androidx-core-ktx",
+    "firebase-messaging",
     "androidx-activity-ktx",
-    "androidx-startup-runtime"
+    "androidx-startup-runtime",
 ]
 
 commonMain = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 90;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -20,13 +20,11 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		7555FFB4242A642300829871 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 10;
+			dstSubfolder = Frameworks;
 			files = (
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -45,12 +43,10 @@
 /* Begin PBXFrameworksBuildPhase section */
 		7555FF78242A565900829871 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				A679C56D2B02DAAC008F0522 /* FirebaseMessaging in Frameworks */,
 				A6EDE9F12B02C93F00DACEA2 /* FirebaseMessaging in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -117,8 +113,6 @@
 			);
 			buildRules = (
 			);
-			dependencies = (
-			);
 			name = iosApp;
 			packageProductDependencies = (
 				A6EDE9F02B02C93F00DACEA2 /* FirebaseMessaging */,
@@ -144,7 +138,6 @@
 				};
 			};
 			buildConfigurationList = 7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */;
-			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -155,6 +148,7 @@
 			packageReferences = (
 				A6EDE9C52B02C93F00DACEA2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
+			preferredProjectObjectVersion = 90;
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -167,51 +161,39 @@
 /* Begin PBXResourcesBuildPhase section */
 		7555FF79242A565900829871 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
 				A6E3F5632C64FB5C00B9A220 /* custom_notification_sound.wav in Resources */,
 				A679C5792B02E1F1008F0522 /* GoogleService-Info.plist in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		7555FFB5242A651A00829871 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :sample:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = (
+				"cd \"$SRCROOT/..\"",
+				"./gradlew :sample:embedAndSignAppleFrameworkForXcode",
+				"",
+			);
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		7555FF77242A565900829871 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		7555FFA3242A565B00829871 /* Debug */ = {
+		7555FFA3242A565B00829871 /* Debug configuration for PBXProject "iosApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -272,7 +254,7 @@
 			};
 			name = Debug;
 		};
-		7555FFA4242A565B00829871 /* Release */ = {
+		7555FFA4242A565B00829871 /* Release configuration for PBXProject "iosApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -327,7 +309,7 @@
 			};
 			name = Release;
 		};
-		7555FFA6242A565B00829871 /* Debug */ = {
+		7555FFA6242A565B00829871 /* Debug configuration for PBXNativeTarget "iosApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -358,7 +340,7 @@
 			};
 			name = Debug;
 		};
-		7555FFA7242A565B00829871 /* Release */ = {
+		7555FFA7242A565B00829871 /* Release configuration for PBXNativeTarget "iosApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -395,19 +377,17 @@
 		7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7555FFA3242A565B00829871 /* Debug */,
-				7555FFA4242A565B00829871 /* Release */,
+				7555FFA3242A565B00829871 /* Debug configuration for PBXProject "iosApp" */,
+				7555FFA4242A565B00829871 /* Release configuration for PBXProject "iosApp" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7555FFA6242A565B00829871 /* Debug */,
-				7555FFA7242A565B00829871 /* Release */,
+				7555FFA6242A565B00829871 /* Debug configuration for PBXNativeTarget "iosApp" */,
+				7555FFA7242A565B00829871 /* Release configuration for PBXNativeTarget "iosApp" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,22 @@
 {
+  "originHash" : "a1569f9895aa2be8e24832f98525d5da4eb90b5d158a82691c15b47eb72a13d7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
-        "version" : "1.2022062300.0"
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
+        "version" : "10.19.2"
       }
     },
     {
@@ -14,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "8872dbd7d947acf757abab933da10e83c1842280",
-        "version" : "10.17.0"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
       }
     },
     {
@@ -23,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "6b332152355c372ace9966d8ee76ed191f97025e",
-        "version" : "10.17.0"
+        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
+        "version" : "10.28.0"
       }
     },
     {
@@ -32,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "aae45a320fd0d11811820335b1eabc8753902a40",
-        "version" : "9.2.5"
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
       }
     },
     {
@@ -41,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
-        "version" : "7.12.1"
+        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
+        "version" : "7.13.3"
       }
     },
     {
@@ -50,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
-        "version" : "1.49.1"
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
       }
     },
     {
@@ -59,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "d415594121c9e8a4f9d79cecee0965cf35e74dbd",
-        "version" : "3.1.1"
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
       }
     },
     {
@@ -77,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
-        "revision" : "9d108e9112aa1d65ce508facf804674546116d9c",
-        "version" : "1.22.3"
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -86,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
-        "version" : "2.30909.0"
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
       }
     },
     {
@@ -95,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
-        "version" : "2.3.1"
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -104,10 +114,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "07f7f26ded8df9645c072f220378879c4642e063",
-        "version" : "1.25.1"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/kmpnotifier/api/kmpnotifier.klib.api
+++ b/kmpnotifier/api/kmpnotifier.klib.api
@@ -6,7 +6,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <io.github.mirzemehdi:kmpnotifier>
+// Library unique name: <KMPNotifierLib:kmpnotifier>
 abstract fun interface com.mmk.kmpnotifier.logger/Logger { // com.mmk.kmpnotifier.logger/Logger|null[0]
     abstract fun log(kotlin/String) // com.mmk.kmpnotifier.logger/Logger.log|log(kotlin.String){}[0]
 }

--- a/kmpnotifier/build.gradle.kts
+++ b/kmpnotifier/build.gradle.kts
@@ -2,8 +2,6 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import flavor.flavorImplementation
-import flavor.Flavor
 import maven.configure
 
 plugins {
@@ -83,11 +81,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
-    }
-
-    dependencies {
-        flavorImplementation(flavorName = Flavor.HUAWEI, dependency = libs.huawei.push)
-        flavorImplementation(flavorName = Flavor.GOOGLE, dependency = libs.firebase.messaging)
     }
 }
 

--- a/kmpnotifier/build.gradle.kts
+++ b/kmpnotifier/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinNativeCocoaPods)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.google.services)
     alias(libs.plugins.dokka)
 }
 

--- a/kmpnotifier/build.gradle.kts
+++ b/kmpnotifier/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinNativeCocoaPods)
     alias(libs.plugins.mavenPublish)
-    alias(libs.plugins.kmpnotifier.library)
     alias(libs.plugins.dokka)
 }
 

--- a/kmpnotifier/build.gradle.kts
+++ b/kmpnotifier/build.gradle.kts
@@ -1,23 +1,27 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import flavor.flavorImplementation
+import flavor.Flavor
+import maven.configure
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinNativeCocoaPods)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.kmpnotifier.library)
+    alias(libs.plugins.dokka)
 }
 
 kotlin {
     explicitApi()
+
     androidTarget {
         publishAllLibraryVariants()
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "1.8"
-            }
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
         }
     }
 
@@ -36,31 +40,23 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-
     cocoapods {
         ios.deploymentTarget = "14.1"
         framework {
-            baseName = "KMPNotifier"
+            baseName = Config.LIBRARY_NAME
             isStatic = true
         }
         noPodspec()
         pod("FirebaseMessaging")
     }
 
-
-
     sourceSets {
-
         androidMain.dependencies {
-            implementation(libs.androidx.startup.runtime)
-            implementation(libs.androidx.core.ktx)
-            implementation(libs.androidx.activity.ktx)
-            implementation(libs.firebase.messaging)
-
+            implementation(libs.bundles.androidMain)
         }
+
         commonMain.dependencies {
-            implementation(libs.koin.core)
-            implementation(libs.kotlinx.coroutine)
+            implementation(libs.bundles.commonMain)
         }
         wasmJsMain.dependencies {
             implementation(libs.kotlinx.browser)
@@ -69,21 +65,15 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }
-
     }
 }
 
 android {
-    namespace = "com.mmk.kmpnotifier"
+    namespace = Config.PACKAGE_ID
     compileSdk = libs.versions.android.compileSdk.get().toInt()
-
-    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-    sourceSets["main"].res.srcDirs("src/androidMain/res")
-    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
     }
 
     packaging {
@@ -92,8 +82,13 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    dependencies {
+        flavorImplementation(flavorName = Flavor.HUAWEI, dependency = libs.huawei.push)
+        flavorImplementation(flavorName = Flavor.GOOGLE, dependency = libs.firebase.messaging)
     }
 }
 
@@ -105,37 +100,21 @@ mavenPublishing {
         )
     )
     coordinates(
-        "io.github.mirzemehdi",
-        "kmpnotifier",
-        project.properties["kmpNotifierVersion"] as String
+        groupId = Config.ARTIFACT_GROUP_ID,
+        artifactId = Config.ARTIFACT_ID,
+        version = Config.ARTIFACT_VERSION
     )
     pom {
-        name = "KMPNotifier"
-        description = "Kotlin Multiplatform Push Notification Library targeting ios and android"
-        url = "https://github.com/mirzemehdi/KMPNotifier/"
-        licenses {
-            license {
-                name.set("Apache-2.0")
-                url.set("https://opensource.org/licenses/Apache-2.0")
-            }
-        }
-        developers {
-            developer {
-                name.set("Mirzamehdi Karimov")
-                email.set("mirzemehdi@gmail.com")
-            }
-        }
-        scm {
-            connection.set("https://github.com/mirzemehdi/KMPNotifier.git")
-            url.set("https://github.com/mirzemehdi/KMPNotifier")
-        }
-        issueManagement {
-            system.set("Github")
-            url.set("https://github.com/mirzemehdi/KMPNotifier/issues")
-        }
+        configure(
+            libraryName = Config.LIBRARY_NAME,
+            libraryDescription = Config.LIBRARY_DESCRIPTION,
+            developerName = Config.DEVELOPER_NAME,
+            developerEmail = Config.DEVELOPER_EMAIL,
+            githubUsername = Config.GITHUB_USERNAME,
+            githubRepositoryName = Config.GITHUB_REPOSITORY_NAME,
+        )
     }
 
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
 }
-

--- a/kmpnotifier/build.gradle.kts
+++ b/kmpnotifier/build.gradle.kts
@@ -1,8 +1,8 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import maven.configure
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.google.services)
-    alias(libs.plugins.kmpnotifier)
 }
 
 kotlin {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,5 +1,7 @@
+import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
@@ -7,21 +9,20 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.composeCompiler)
-    id("com.google.gms.google-services")
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.kmpnotifier)
 }
 
 kotlin {
 
     androidTarget {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "1.8"
-            }
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
         }
     }
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        moduleName = "sample"
+        outputModuleName = "sample"
         browser {
             commonWebpackConfig {
                 outputFileName = "sample.js"
@@ -73,10 +74,6 @@ android {
     namespace = "com.mmk.kmpnotifier.sample"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
-    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-    sourceSets["main"].res.srcDirs("src/androidMain/res")
-    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
-
     defaultConfig {
         applicationId = "com.mmk.kmpnotifier.sample"
         minSdk = libs.versions.android.minSdk.get().toInt()
@@ -98,13 +95,15 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
+
     dependencies {
         debugImplementation(libs.compose.ui.tooling)
     }
 }
+
 compose.desktop {
     application {
         mainClass = "com.mmk.kmpnotifier.sample.MainKt"

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
@@ -2,7 +2,6 @@ package com.mmk.kmpnotifier.sample
 
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.PayloadData
-import com.mmk.kmpnotifier.notification.PushNotifier
 
 
 object AppInitializer {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,11 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.name = "KMPNotifierLib"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
     repositories {
+        maven("https://developer.huawei.com/repo/")
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         google()
         gradlePluginPortal()
@@ -14,9 +17,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://developer.huawei.com/repo/")
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
-
 include(":kmpnotifier")
 include(":sample")


### PR DESCRIPTION
This commit introduces several build system improvements and dependency updates:

**Build Configuration:**
- Centralized common build configurations (package ID, artifact details, developer information, etc.) into a `Config.kt` file within `buildSrc`. This promotes consistency and easier management of project-wide settings.
- Created a `mavenPublish.kt` helper in `buildSrc` to streamline the configuration of Maven POM details.
- Upgraded Android Gradle Plugin, Kotlin, Compose, and other dependencies to their latest versions.
- Updated Java version to 21 for compilation.
- Migrated dependency definitions to version catalog bundles for `androidMain` and `commonMain` source sets.

**Dependency Management:**
- Updated various library versions in `libs.versions.toml`.
- Added Huawei Push service dependency.
- Added Huawei Maven repository to `settings.gradle.kts`.

**CI:**
- Updated GitHub Actions workflow to use JDK 21.

**Other Changes:**
- Increased `kmpNotifierVersion` to `1.5.2`.
- Removed an unused import in `AppInitializer.kt`.
- Adjusted JVM target to 21 in `kmpnotifier/build.gradle.kts` and `sample/build.gradle.kts`.
- Updated Gradle wrapper to version 8.14.2.
- Enabled Dokka V2 plugin mode.